### PR TITLE
feat: 週次・月次AIトレンドレポート生成機能を追加

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -237,6 +237,8 @@ main { padding: 16px 24px; max-width: 900px; }
   <div id="panel-twitter" class="panel">
     <div class="cards"><p class="empty">No articles</p></div>
   </div>
+  <div class="archive-section"><h2>Trend Reports</h2><div class="archive-list"><a href="monthly/2026-03.html" class="archive-link"><span>&#128197; 2026-03</span><span class="archive-count">月次レポート</span></a>
+<a href="weekly/2026-W11.html" class="archive-link"><span>&#128202; 2026-W11</span><span class="archive-count">週次レポート</span></a></div></div>
   <div class="archive-section"><h2>Archive</h2><div class="archive-list"><a href="daily/2026-03-10.html" class="archive-link"><span>2026-03-10</span><span class="archive-count">27 articles</span></a>
 <a href="daily/2026-03-09.html" class="archive-link"><span>2026-03-09</span><span class="archive-count">25 articles</span></a>
 <a href="daily/2026-03-08.html" class="archive-link"><span>2026-03-08</span><span class="archive-count">29 articles</span></a>

--- a/docs/monthly/2026-03.html
+++ b/docs/monthly/2026-03.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI トレンドレポート 2026-03</title>
+<style>:root {
+  --bg: #0f0f13;
+  --surface: #1a1a22;
+  --border: #2a2a38;
+  --text: #e8e8f0;
+  --muted: #7a7a9a;
+  --accent: #7c6af7;
+  --green: #4ade80;
+  --orange: #fb923c;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+}
+header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.header-top {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.3px; }
+h1 a { color: var(--text); text-decoration: none; }
+h1 a:hover { color: var(--accent); }
+.subtitle { font-size: 14px; color: var(--muted); }
+.period-badge {
+  display: inline-block;
+  background: var(--accent);
+  color: white;
+  border-radius: 6px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+main { padding: 20px 24px; max-width: 860px; }
+section { margin-bottom: 28px; }
+section h2 {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 14px;
+  color: var(--text);
+  border-left: 3px solid var(--accent);
+  padding-left: 10px;
+}
+.summary-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 20px;
+  line-height: 1.8;
+  color: var(--text);
+}
+.trends-list { display: flex; flex-direction: column; gap: 12px; }
+.trend-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+}
+.trend-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.trend-desc { color: var(--text); line-height: 1.7; }
+.keywords { display: flex; flex-wrap: wrap; gap: 8px; }
+.keyword {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 4px 14px;
+  font-size: 12px;
+  color: var(--text);
+}
+.outlook-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--green);
+  border-radius: 10px;
+  padding: 16px 20px;
+  line-height: 1.8;
+}
+.articles-grid { display: flex; flex-direction: column; gap: 8px; }
+.article-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.article-source {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.article-link {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.article-link:hover { color: var(--accent); }
+.article-score { color: var(--muted); font-size: 11px; white-space: nowrap; flex-shrink: 0; }
+.back-link {
+  display: inline-block;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.back-link:hover { text-decoration: underline; }
+.stats-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.stat-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 16px;
+  text-align: center;
+  min-width: 80px;
+}
+.stat-num { font-size: 22px; font-weight: 700; color: var(--accent); }
+.stat-label { font-size: 11px; color: var(--muted); margin-top: 2px; }
+@media (max-width: 600px) {
+  header, main { padding-left: 16px; padding-right: 16px; }
+}</style>
+</head>
+<body>
+<header>
+  <div class="header-top">
+    <h1><a href="../index.html">AI Feed</a></h1>
+    <span class="period-badge">月次レポート</span>
+    <span class="subtitle">2026-03 (2026-03-01 〜 2026-03-31)</span>
+  </div>
+</header>
+<main>
+  <a href="../index.html" class="back-link">&larr; 最新フィードへ</a>
+
+  <div class="stats-row">
+    <div class="stat-box"><div class="stat-num">99</div><div class="stat-label">総記事数</div></div>
+    <div class="stat-box"><div class="stat-num">50</div><div class="stat-label">HN</div></div>
+    <div class="stat-box"><div class="stat-num">49</div><div class="stat-label">Hatena</div></div>
+    <div class="stat-box"><div class="stat-num">0</div><div class="stat-label">Twitter</div></div>
+  </div>
+
+  <section>
+    <h2>📋 月次サマリー</h2>
+    <div class="summary-box">2026-03 のAIトレンドレポートです。</div>
+  </section>
+
+  <section>
+    <h2>🔥 主要トレンド</h2>
+    <div class="trends-list"></div>
+  </section>
+
+  <section>
+    <h2>💡 注目キーワード</h2>
+    <div class="keywords"></div>
+  </section>
+
+  <section>
+    <h2>🟠 HN ランキング TOP10</h2>
+    <div class="articles-grid"><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://www.svd.se/a/K8nrV4/metas-ai-smart-glasses-and-data-privacy-concerns-workers-say-we-see-everything" target="_blank" class="article-link">MetaのAIスマートグラスとデータプライバシーへの懸念</a><span class="article-score">▲ 1425</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://openai.com/index/introducing-gpt-5-4/" target="_blank" class="article-link">GPT-5.4</a><span class="article-score">▲ 886</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://techcrunch.com/2026/03/04/anthropic-ceo-dario-amodei-calls-openais-messaging-around-military-deal-straight-up-lies-report-says/" target="_blank" class="article-link">Dario Amodei、OpenAIの軍事契約に関する発言を「完全な嘘」と批判</a><span class="article-score">▲ 784</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://simonwillison.net/2026/Mar/4/qwen/" target="_blank" class="article-link">Qwenの世界で何かが動いている</a><span class="article-score">▲ 774</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://acko.net/blog/the-l-in-llm-stands-for-lying/" target="_blank" class="article-link">「LLM」のLはLying（嘘）の略</a><span class="article-score">▲ 643</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://futurism.com/artificial-intelligence/ars-technica-fires-reporter-ai-quotes" target="_blank" class="article-link">Ars Technica、AI捏造引用問題でライターを解雇</a><span class="article-score">▲ 601</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://news.ycombinator.com/item?id=47282777" target="_blank" class="article-link">60歳の私に情熱を再び灯したClaude Code</a><span class="article-score">▲ 586</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://www.anthropic.com/news/mozilla-firefox-security" target="_blank" class="article-link">AnthropicのRed TeamによるFirefoxのセキュリティ強化</a><span class="article-score">▲ 580</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://writings.hongminhee.org/2026/03/legal-vs-legitimate/" target="_blank" class="article-link">合法と正当は同じか：AIによる再実装とコピーレフトの侵食</a><span class="article-score">▲ 507</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://www.wsj.com/politics/national-security/pentagon-formally-labels-anthropic-supply-chain-risk-escalating-conflict-ebdf0523" target="_blank" class="article-link">国防総省、Anthropicをサプライチェーンリスクに正式認定</a><span class="article-score">▲ 412</span></div></div>
+  </section>
+
+  <section>
+    <h2>🔵 はてな ランキング TOP10</h2>
+    <div class="articles-grid"><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://zenn.dev/hiraly/articles/3409b886607274" target="_blank" class="article-link">MCPはなぜCLIに負けたのか —— 経緯と構造を整理する</a><span class="article-score">🔖 560</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://note.com/fromdusktildawn/n/n36b18b002010" target="_blank" class="article-link">ChatGPT5.4Proに小説を書かせたら「AIが書いたにしては面白い」というレベルをはるかに超えてて、仰天した｜ふろむだ</a><span class="article-score">🔖 464</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://type.jp/et/feature/30605/" target="_blank" class="article-link">南場智子「ますます“速さ”が命題に」DeNA AI Day2026全文書き起こし - エンジニアtype | 転職type</a><span class="article-score">🔖 463</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://nyosegawa.github.io/posts/harness-engineering-best-practices-2026/" target="_blank" class="article-link">Claude Code / Codex ユーザーのための誰でもわかるHarness Engineeringベストプラクティス</a><span class="article-score">🔖 297</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://atmarkit.itmedia.co.jp/ait/articles/2603/10/news010.html" target="_blank" class="article-link">【無料】Anthropic公式「エージェントスキル入門」講座が公開　Claude Codeでの活用法が分かる22分の動画</a><span class="article-score">🔖 256</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://www.nikkei.com/article/DGXZQOGN060800W6A300C2000000/" target="_blank" class="article-link">日本生命、米国でOpenAIを提訴　「ChatGPTが非弁行為」 - 日本経済新聞</a><span class="article-score">🔖 195</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://zenn.dev/knowledgework/articles/claude-code-organization-plan-guide" target="_blank" class="article-link">Claude Codeを組織導入するためのプラン選定ガイド</a><span class="article-score">🔖 186</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://zenn.dev/komlock_lab/articles/openai-symphony" target="_blank" class="article-link">Symphony - OpenAIが発表したチケット駆動AI開発ツールについて</a><span class="article-score">🔖 154</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://zenn.dev/mgdx_blog/articles/8f7994ad84151d" target="_blank" class="article-link">コードレビューにClaude Code subagentsを導入したら、レビューレベルが改善した話</a><span class="article-score">🔖 146</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://blog.inorinrinrin.com/entry/2026/03/07/180419" target="_blank" class="article-link">3分で学ぶ GitHub Copilot CLI の基本とベストプラクティス - プププなテクブ</a><span class="article-score">🔖 142</span></div></div>
+  </section>
+
+  <section>
+    <h2>🌅 展望</h2>
+    <div class="outlook-box"></div>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/weekly/2026-W11.html
+++ b/docs/weekly/2026-W11.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI トレンドレポート 2026-W11</title>
+<style>:root {
+  --bg: #0f0f13;
+  --surface: #1a1a22;
+  --border: #2a2a38;
+  --text: #e8e8f0;
+  --muted: #7a7a9a;
+  --accent: #7c6af7;
+  --green: #4ade80;
+  --orange: #fb923c;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+}
+header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.header-top {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.3px; }
+h1 a { color: var(--text); text-decoration: none; }
+h1 a:hover { color: var(--accent); }
+.subtitle { font-size: 14px; color: var(--muted); }
+.period-badge {
+  display: inline-block;
+  background: var(--accent);
+  color: white;
+  border-radius: 6px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+main { padding: 20px 24px; max-width: 860px; }
+section { margin-bottom: 28px; }
+section h2 {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 14px;
+  color: var(--text);
+  border-left: 3px solid var(--accent);
+  padding-left: 10px;
+}
+.summary-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 20px;
+  line-height: 1.8;
+  color: var(--text);
+}
+.trends-list { display: flex; flex-direction: column; gap: 12px; }
+.trend-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+}
+.trend-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.trend-desc { color: var(--text); line-height: 1.7; }
+.keywords { display: flex; flex-wrap: wrap; gap: 8px; }
+.keyword {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 4px 14px;
+  font-size: 12px;
+  color: var(--text);
+}
+.outlook-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--green);
+  border-radius: 10px;
+  padding: 16px 20px;
+  line-height: 1.8;
+}
+.articles-grid { display: flex; flex-direction: column; gap: 8px; }
+.article-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.article-source {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.article-link {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.article-link:hover { color: var(--accent); }
+.article-score { color: var(--muted); font-size: 11px; white-space: nowrap; flex-shrink: 0; }
+.back-link {
+  display: inline-block;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.back-link:hover { text-decoration: underline; }
+.stats-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.stat-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 16px;
+  text-align: center;
+  min-width: 80px;
+}
+.stat-num { font-size: 22px; font-weight: 700; color: var(--accent); }
+.stat-label { font-size: 11px; color: var(--muted); margin-top: 2px; }
+@media (max-width: 600px) {
+  header, main { padding-left: 16px; padding-right: 16px; }
+}</style>
+</head>
+<body>
+<header>
+  <div class="header-top">
+    <h1><a href="../index.html">AI Feed</a></h1>
+    <span class="period-badge">週次レポート</span>
+    <span class="subtitle">2026-W11 (2026-03-09 〜 2026-03-15)</span>
+  </div>
+</header>
+<main>
+  <a href="../index.html" class="back-link">&larr; 最新フィードへ</a>
+
+  <div class="stats-row">
+    <div class="stat-box"><div class="stat-num">46</div><div class="stat-label">総記事数</div></div>
+    <div class="stat-box"><div class="stat-num">27</div><div class="stat-label">HN</div></div>
+    <div class="stat-box"><div class="stat-num">19</div><div class="stat-label">Hatena</div></div>
+    <div class="stat-box"><div class="stat-num">0</div><div class="stat-label">Twitter</div></div>
+  </div>
+
+  <section>
+    <h2>📋 週次サマリー</h2>
+    <div class="summary-box">今週のAIシーンはYann LeCunの10億ドル調達から著作権問題まで幅広いトピックが活発に議論された。特にオープンソースAIの合法性と倫理を問う記事が高い反響を呼んだ。</div>
+  </section>
+
+  <section>
+    <h2>🔥 主要トレンド</h2>
+    <div class="trends-list"><div class="trend-item"><div class="trend-title">AI資金調達ラッシュ</div><div class="trend-desc">Yann LeCunのスタートアップがヨーロッパ史上最大のシードラウンドを実施するなど、AI関連の大型投資が続いている。</div></div>
+<div class="trend-item"><div class="trend-title">著作権とコピーレフトの侵食</div><div class="trend-desc">AIがオープンソースライセンスをどのように扱うべきかを巡る議論が活発化。法的に合法でも倫理的に正当かという問いが焦点に。</div></div>
+<div class="trend-item"><div class="trend-title">AIコスト論争</div><div class="trend-desc">Claude Codeのコストに関する誤解を指摘する記事が大きな注目を集め、AIサービスの収益モデルに関心が集まった。</div></div>
+</div>
+  </section>
+
+  <section>
+    <h2>💡 注目キーワード</h2>
+    <div class="keywords"><span class="keyword">LLM</span><span class="keyword">Claude</span><span class="keyword">OpenAI</span><span class="keyword">著作権</span><span class="keyword">資金調達</span><span class="keyword">オープンソース</span><span class="keyword">DeepMind</span></div>
+  </section>
+
+  <section>
+    <h2>🟠 HN ランキング TOP5</h2>
+    <div class="articles-grid"><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://news.ycombinator.com/item?id=47282777" target="_blank" class="article-link">Tell HN: 60歳の私に、Claude Codeが情熱を再点火した</a><span class="article-score">▲ 1049</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://openai.com/index/introducing-gpt-5-4/" target="_blank" class="article-link">GPT-5.4</a><span class="article-score">▲ 1014</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://www.anthropic.com/news/mozilla-firefox-security" target="_blank" class="article-link">AnthropicのRed TeamによるFirefoxのセキュリティ強化</a><span class="article-score">▲ 626</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://writings.hongminhee.org/2026/03/legal-vs-legitimate/" target="_blank" class="article-link">合法と正当は同じか：AIによる再実装とコピーレフトの侵食</a><span class="article-score">▲ 507</span></div><div class="article-item"><span class="article-source" style="color:#ff6600">HN</span><a href="https://unsloth.ai/docs/models/qwen3.5" target="_blank" class="article-link">Qwen 3.5をローカルで実行する方法</a><span class="article-score">▲ 473</span></div></div>
+  </section>
+
+  <section>
+    <h2>🔵 はてな ランキング TOP5</h2>
+    <div class="articles-grid"><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://nyosegawa.github.io/posts/harness-engineering-best-practices-2026/" target="_blank" class="article-link">Claude Code / Codex ユーザーのための誰でもわかるHarness Engineeringベストプラクティス</a><span class="article-score">🔖 297</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://atmarkit.itmedia.co.jp/ait/articles/2603/10/news010.html" target="_blank" class="article-link">【無料】Anthropic公式「エージェントスキル入門」講座が公開　Claude Codeでの活用法が分かる22分の動画</a><span class="article-score">🔖 256</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://zenn.dev/acntechjp/articles/c1296f425baf03" target="_blank" class="article-link">Claude Code が RAG を捨てた理由 -「Agentic Search」という選択肢</a><span class="article-score">🔖 72</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://tacoms-inc.hatenablog.com/entry/2026/03/10/142115" target="_blank" class="article-link">Devinが本番APIで障害を起こした経緯と学び - tacomsテックブログ</a><span class="article-score">🔖 69</span></div><div class="article-item"><span class="article-source" style="color:#008fde">Hatena</span><a href="https://econ101.jp/noah-smith_3rd-scenario/" target="_blank" class="article-link">ノア・スミス「誰も語っていないAIバブル崩壊の第三シナリオ」（2025年12月9日）</a><span class="article-score">🔖 68</span></div></div>
+  </section>
+
+  <section>
+    <h2>🌅 展望</h2>
+    <div class="outlook-box">来週はLLMの新モデルリリースや規制動向に注目が集まりそう。特にEUのAI法の実装に関する議論が進む可能性がある。</div>
+  </section>
+</main>
+</body>
+</html>

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -13,6 +13,8 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent
 FEED_PATH = ROOT / "docs" / "feed.json"
 DAILY_DIR = ROOT / "docs" / "daily"
+WEEKLY_DIR = ROOT / "docs" / "weekly"
+MONTHLY_DIR = ROOT / "docs" / "monthly"
 OUTPUT_PATH = ROOT / "docs" / "index.html"
 
 SOURCE_LABELS = {
@@ -288,7 +290,19 @@ def load_daily_dates() -> list[tuple[str, int]]:
     return dates
 
 
-def generate_index_html(feed: dict, daily_dates: list[tuple[str, int]]) -> str:
+def load_trend_reports() -> dict[str, list[str]]:
+    """Return {'weekly': [...filenames...], 'monthly': [...filenames...]} sorted newest first."""
+    result: dict[str, list[str]] = {"weekly": [], "monthly": []}
+    for key, dir_path in [("weekly", WEEKLY_DIR), ("monthly", MONTHLY_DIR)]:
+        if dir_path.exists():
+            result[key] = sorted(
+                [f.stem for f in dir_path.glob("*.html")],
+                reverse=True,
+            )
+    return result
+
+
+def generate_index_html(feed: dict, daily_dates: list[tuple[str, int]], trend_reports: dict | None = None) -> str:
     updated_str = format_updated(feed.get("updated_at", ""))
     hn_items = feed.get("hackernews", [])
     hatena_items = feed.get("hatena", [])
@@ -309,6 +323,29 @@ def generate_index_html(feed: dict, daily_dates: list[tuple[str, int]]) -> str:
             f'<div class="archive-list">{links}</div>'
             f"</div>"
         )
+
+    trend_html = ""
+    if trend_reports:
+        weekly_links = "\n".join(
+            f'<a href="weekly/{name}.html" class="archive-link">'
+            f"<span>&#128202; {name}</span>"
+            f'<span class="archive-count">週次レポート</span></a>'
+            for name in trend_reports.get("weekly", [])[:8]
+        )
+        monthly_links = "\n".join(
+            f'<a href="monthly/{name}.html" class="archive-link">'
+            f"<span>&#128197; {name}</span>"
+            f'<span class="archive-count">月次レポート</span></a>'
+            for name in trend_reports.get("monthly", [])[:6]
+        )
+        if weekly_links or monthly_links:
+            combined = "\n".join(filter(None, [monthly_links, weekly_links]))
+            trend_html = (
+                f'<div class="archive-section">'
+                f"<h2>Trend Reports</h2>"
+                f'<div class="archive-list">{combined}</div>'
+                f"</div>"
+            )
 
     return f"""<!DOCTYPE html>
 <html lang="ja">
@@ -352,6 +389,7 @@ def generate_index_html(feed: dict, daily_dates: list[tuple[str, int]]) -> str:
   <div id="panel-twitter" class="panel">
     <div class="cards">{render_cards(twitter_items)}</div>
   </div>
+  {trend_html}
   {archive_html}
 </main>
 <script>{TAB_JS}</script>
@@ -437,7 +475,8 @@ def main() -> None:
 
     # Generate index.html with archive links
     daily_dates = load_daily_dates()
-    html = generate_index_html(feed, daily_dates)
+    trend_reports = load_trend_reports()
+    html = generate_index_html(feed, daily_dates, trend_reports)
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
         f.write(html)

--- a/scripts/generate_trend_report.py
+++ b/scripts/generate_trend_report.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+Claude のトレンド分析結果（構造化JSON）を受け取り、週次・月次レポート HTML を生成する。
+
+使い方:
+    python scripts/generate_trend_report.py --mode weekly '<JSON>'
+    python scripts/generate_trend_report.py --mode monthly '<JSON>'
+    python scripts/generate_trend_report.py --mode weekly --date 2026-03-10 '<JSON>'
+
+JSON スキーマ:
+    {
+        "summary": "string",       # 週/月の全体まとめ
+        "trends": [                 # トレンド項目（3〜6件）
+            {"title": "string", "description": "string"}
+        ],
+        "keywords": ["string"],    # 注目キーワード
+        "outlook": "string"        # 来週/来月の展望
+    }
+"""
+
+import argparse
+import json
+import sys
+from datetime import date, datetime, timedelta
+from html import escape
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+DAILY_DIR = ROOT / "docs" / "daily"
+WEEKLY_DIR = ROOT / "docs" / "weekly"
+MONTHLY_DIR = ROOT / "docs" / "monthly"
+
+# generate_html.py と共通の CSS ベース
+CSS = """\
+:root {
+  --bg: #0f0f13;
+  --surface: #1a1a22;
+  --border: #2a2a38;
+  --text: #e8e8f0;
+  --muted: #7a7a9a;
+  --accent: #7c6af7;
+  --green: #4ade80;
+  --orange: #fb923c;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+}
+header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.header-top {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.3px; }
+h1 a { color: var(--text); text-decoration: none; }
+h1 a:hover { color: var(--accent); }
+.subtitle { font-size: 14px; color: var(--muted); }
+.period-badge {
+  display: inline-block;
+  background: var(--accent);
+  color: white;
+  border-radius: 6px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+main { padding: 20px 24px; max-width: 860px; }
+section { margin-bottom: 28px; }
+section h2 {
+  font-size: 16px;
+  font-weight: 700;
+  margin-bottom: 14px;
+  color: var(--text);
+  border-left: 3px solid var(--accent);
+  padding-left: 10px;
+}
+.summary-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 20px;
+  line-height: 1.8;
+  color: var(--text);
+}
+.trends-list { display: flex; flex-direction: column; gap: 12px; }
+.trend-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+}
+.trend-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+.trend-desc { color: var(--text); line-height: 1.7; }
+.keywords { display: flex; flex-wrap: wrap; gap: 8px; }
+.keyword {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 4px 14px;
+  font-size: 12px;
+  color: var(--text);
+}
+.outlook-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--green);
+  border-radius: 10px;
+  padding: 16px 20px;
+  line-height: 1.8;
+}
+.articles-grid { display: flex; flex-direction: column; gap: 8px; }
+.article-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.article-source {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.article-link {
+  color: var(--text);
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.article-link:hover { color: var(--accent); }
+.article-score { color: var(--muted); font-size: 11px; white-space: nowrap; flex-shrink: 0; }
+.back-link {
+  display: inline-block;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.back-link:hover { text-decoration: underline; }
+.stats-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.stat-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 16px;
+  text-align: center;
+  min-width: 80px;
+}
+.stat-num { font-size: 22px; font-weight: 700; color: var(--accent); }
+.stat-label { font-size: 11px; color: var(--muted); margin-top: 2px; }
+@media (max-width: 600px) {
+  header, main { padding-left: 16px; padding-right: 16px; }
+}"""
+
+
+def get_week_range(ref_date: date) -> tuple[date, date]:
+    """Return (monday, sunday) of the ISO week containing ref_date."""
+    monday = ref_date - timedelta(days=ref_date.weekday())
+    sunday = monday + timedelta(days=6)
+    return monday, sunday
+
+
+def get_month_range(ref_date: date) -> tuple[date, date]:
+    """Return (first_day, last_day) of ref_date's month."""
+    first = ref_date.replace(day=1)
+    if ref_date.month == 12:
+        last = date(ref_date.year + 1, 1, 1) - timedelta(days=1)
+    else:
+        last = date(ref_date.year, ref_date.month + 1, 1) - timedelta(days=1)
+    return first, last
+
+
+def collect_articles(start: date, end: date) -> list[dict]:
+    """Collect all unique articles from daily JSONs in [start, end]."""
+    seen_urls: set[str] = set()
+    articles: list[dict] = []
+    current = start
+    while current <= end:
+        path = DAILY_DIR / f"{current.isoformat()}.json"
+        if path.exists():
+            try:
+                with open(path, encoding="utf-8") as f:
+                    data = json.load(f)
+                for key in ["hackernews", "hatena", "twitter"]:
+                    for item in data.get(key, []):
+                        url = item.get("url", "")
+                        if url and url not in seen_urls:
+                            seen_urls.add(url)
+                            articles.append(item)
+            except Exception as e:
+                print(f"Warning: failed to read {path}: {e}", file=sys.stderr)
+        current += timedelta(days=1)
+    return articles
+
+
+def top_articles(articles: list[dict], source: str, score_key: str, n: int = 10) -> list[dict]:
+    """Return top n articles from given source sorted by score_key desc."""
+    items = [a for a in articles if a.get("source") == source and a.get(score_key)]
+    items.sort(key=lambda x: x.get(score_key, 0), reverse=True)
+    return items[:n]
+
+
+def article_item_html(item: dict) -> str:
+    source = item.get("source", "")
+    color = {"hackernews": "#ff6600", "hatena": "#008fde", "twitter": "#1d9bf0"}.get(source, "#888")
+    label = {"hackernews": "HN", "hatena": "Hatena", "twitter": "Twitter"}.get(source, source)
+    title = escape(item.get("title_ja") or item.get("title", ""))
+    url = escape(item.get("url", "#"))
+    score = item.get("score") or item.get("bookmarks") or ""
+    score_icon = "▲" if source == "hackernews" else ("🔖" if source == "hatena" else "")
+    score_html = f'<span class="article-score">{score_icon} {score}</span>' if score else ""
+    return (
+        f'<div class="article-item">'
+        f'<span class="article-source" style="color:{color}">{label}</span>'
+        f'<a href="{url}" target="_blank" class="article-link">{title}</a>'
+        f"{score_html}"
+        f"</div>"
+    )
+
+
+def render_trend_html(
+    analysis: dict,
+    period_label: str,
+    period_range: str,
+    articles: list[dict],
+    mode: str,
+) -> str:
+    summary = escape(analysis.get("summary", ""))
+    trends = analysis.get("trends", [])
+    keywords = analysis.get("keywords", [])
+    outlook = escape(analysis.get("outlook", ""))
+
+    trends_html = ""
+    for t in trends:
+        title = escape(t.get("title", ""))
+        desc = escape(t.get("description", ""))
+        trends_html += (
+            f'<div class="trend-item">'
+            f'<div class="trend-title">{title}</div>'
+            f'<div class="trend-desc">{desc}</div>'
+            f"</div>\n"
+        )
+
+    keywords_html = "".join(
+        f'<span class="keyword">{escape(kw)}</span>' for kw in keywords
+    )
+
+    # Top articles
+    hn_top = top_articles(articles, "hackernews", "score", 5 if mode == "weekly" else 10)
+    hatena_top = top_articles(articles, "hatena", "bookmarks", 5 if mode == "weekly" else 10)
+    hn_html = "".join(article_item_html(a) for a in hn_top)
+    hatena_html = "".join(article_item_html(a) for a in hatena_top)
+
+    hn_count = sum(1 for a in articles if a.get("source") == "hackernews")
+    hatena_count = sum(1 for a in articles if a.get("source") == "hatena")
+    twitter_count = sum(1 for a in articles if a.get("source") == "twitter")
+    total = len(articles)
+
+    period_type = "週次" if mode == "weekly" else "月次"
+
+    return f"""<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI トレンドレポート {period_label}</title>
+<style>{CSS}</style>
+</head>
+<body>
+<header>
+  <div class="header-top">
+    <h1><a href="../index.html">AI Feed</a></h1>
+    <span class="period-badge">{period_type}レポート</span>
+    <span class="subtitle">{period_label} ({period_range})</span>
+  </div>
+</header>
+<main>
+  <a href="../index.html" class="back-link">&larr; 最新フィードへ</a>
+
+  <div class="stats-row">
+    <div class="stat-box"><div class="stat-num">{total}</div><div class="stat-label">総記事数</div></div>
+    <div class="stat-box"><div class="stat-num">{hn_count}</div><div class="stat-label">HN</div></div>
+    <div class="stat-box"><div class="stat-num">{hatena_count}</div><div class="stat-label">Hatena</div></div>
+    <div class="stat-box"><div class="stat-num">{twitter_count}</div><div class="stat-label">Twitter</div></div>
+  </div>
+
+  <section>
+    <h2>📋 {period_type}サマリー</h2>
+    <div class="summary-box">{summary}</div>
+  </section>
+
+  <section>
+    <h2>🔥 主要トレンド</h2>
+    <div class="trends-list">{trends_html}</div>
+  </section>
+
+  <section>
+    <h2>💡 注目キーワード</h2>
+    <div class="keywords">{keywords_html}</div>
+  </section>
+
+  <section>
+    <h2>🟠 HN ランキング TOP{len(hn_top)}</h2>
+    <div class="articles-grid">{hn_html or '<p style="color:var(--muted)">記事なし</p>'}</div>
+  </section>
+
+  <section>
+    <h2>🔵 はてな ランキング TOP{len(hatena_top)}</h2>
+    <div class="articles-grid">{hatena_html or '<p style="color:var(--muted)">記事なし</p>'}</div>
+  </section>
+
+  <section>
+    <h2>🌅 展望</h2>
+    <div class="outlook-box">{outlook}</div>
+  </section>
+</main>
+</body>
+</html>"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate AI trend report HTML")
+    parser.add_argument("--mode", choices=["weekly", "monthly"], required=True)
+    parser.add_argument("--date", default=None, help="Reference date YYYY-MM-DD (default: today)")
+    parser.add_argument("analysis_json", nargs="?", default="", help="Trend analysis JSON from Claude")
+    args = parser.parse_args()
+
+    ref = date.fromisoformat(args.date) if args.date else date.today()
+
+    if args.mode == "weekly":
+        start, end = get_week_range(ref)
+        iso_year, iso_week, _ = ref.isocalendar()
+        period_label = f"{iso_year}-W{iso_week:02d}"
+        period_range = f"{start.isoformat()} 〜 {end.isoformat()}"
+        out_dir = WEEKLY_DIR
+        out_name = f"{period_label}.html"
+    else:
+        start, end = get_month_range(ref)
+        period_label = ref.strftime("%Y-%m")
+        period_range = f"{start.isoformat()} 〜 {end.isoformat()}"
+        out_dir = MONTHLY_DIR
+        out_name = f"{period_label}.html"
+
+    # Parse analysis JSON
+    raw = args.analysis_json.strip()
+    if raw:
+        try:
+            analysis = json.loads(raw)
+        except json.JSONDecodeError as e:
+            print(f"Warning: failed to parse analysis JSON ({e}), using empty analysis", file=sys.stderr)
+            analysis = {}
+    else:
+        analysis = {}
+
+    # Fill in defaults if analysis is empty / incomplete
+    if not analysis.get("summary"):
+        analysis["summary"] = f"{period_label} のAIトレンドレポートです。"
+    if not analysis.get("trends"):
+        analysis["trends"] = []
+    if not analysis.get("keywords"):
+        analysis["keywords"] = []
+    if not analysis.get("outlook"):
+        analysis["outlook"] = ""
+
+    # Collect articles
+    articles = collect_articles(start, end)
+    print(f"Collected {len(articles)} articles for {period_label} ({start} - {end})")
+
+    # Generate HTML
+    html = render_trend_html(analysis, period_label, period_range, articles, args.mode)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / out_name
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(html)
+    print(f"Generated {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- scripts/generate_trend_report.py を新規作成
  - --mode weekly/monthly と --date で対象期間を指定
  - Claudeのトレンド分析JSON（構造化出力）を受け取りHTMLを生成
  - daily/*.json から記事を収集してHNスコア/はてなBM順ランキングも掲載
- generate_html.py に Trend Reports セクションを追加
  - index.html から weekly/ monthly/ レポートへのリンクを表示
- 既存の claude-code-action ワークフローは一切変更なし